### PR TITLE
AKUS36

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -10,7 +10,7 @@ class Admin::InvoicesController < ApplicationController
   def update
     @invoice = Invoice.find(params[:id])
     if @invoice.update(invoice_params)
-      redirect_to admin_invoice_path(@invoice), notice: "Invoice has been Updated"
+      redirect_to admin_invoice_path(@invoice), notice: "Invoice has been Updated to #{@invoice.status}"
     else
       render :show
     end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,19 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    @invoice = Invoice.find(params[:id])
+    if @invoice.update(invoice_params)
+      redirect_to admin_invoice_path(@invoice), notice: "Invoice has been Updated"
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def invoice_params
+    params.require(:invoice).permit(:status)
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,5 +1,9 @@
 <h1><%= "Invoice Number: #{@invoice.id}" %></h1>
-<p><%= "Invoice Status: #{@invoice.status}" %></p>
+<%= form_for @invoice, url: admin_invoice_path  do |f| %>
+  <%= f.label :invoice_status, "Invoice Status:" %>
+  <%= f.select(:status, Invoice.statuses.keys.map{|status|[status.capitalize, status]}) %>
+  <%= f.submit "Update Invoice Status" %>
+<% end %>
 <p><%= "Created On: #{@invoice.created_at.strftime("%A, %B %d, %Y")}" %></p>
 <p><%= "Customer: #{@invoice.customer_full_name}" %></p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+    <% flash.each do |key, message| %>
+      <div class="flash <%= key %>"><%= message %></div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
         patch :update_status, to: "merchant_status#update"
       end
     end
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
   
   resources :merchants, only: [:index, :show] do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -100,4 +100,19 @@ RSpec.describe "the admin invoices show page" do
       expect(page).to have_content("Total Invoice Revenue: $40.00")
     end
   end
+
+  it "allows an admin to update the status" do
+    invoice = create(:invoice, status: "in progress")
+
+    visit admin_invoice_path(invoice)
+
+    expect(page).to have_select("Status", selected: "Pending")
+
+    select "Completed", from: "Status"
+    click_button "Update Invoice Status"
+
+    expect(current_path).to eq(admin_invoice_path(invoice))
+    expect(page).to have_select("Status", selected: "Completed")
+    expect(page).to have_select("Invoice has been Updated")
+  end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "the admin invoices show page" do
     visit admin_invoice_path(@invoice1.id)
 
     expect(page).to have_content("Invoice Number: #{@invoice1.id}")
-    expect(page).to have_content("Invoice Status: #{@invoice1.status}")
+    expect(page).to have_select("invoice_status" , selected: @invoice1.status.capitalize)
     expect(page).to have_content("Created On: #{@invoice1.created_at.strftime("%A, %B %d, %Y")}")
     expect(page).to have_content("Customer: #{@customer.first_name} #{@customer.last_name}")
   end
@@ -38,7 +38,7 @@ RSpec.describe "the admin invoices show page" do
     visit admin_invoice_path(@invoice2.id)
 
     expect(page).to have_content("Invoice Number: #{@invoice2.id}")
-    expect(page).to have_content("Invoice Status: #{@invoice2.status}")
+    expect(page).to have_select("invoice_status" , selected: @invoice2.status.capitalize)
     expect(page).to have_content("Created On: #{@invoice2.created_at.strftime("%A, %B %d, %Y")}")
     expect(page).to have_content("Customer: #{@customer.first_name} #{@customer.last_name}")
   end
@@ -47,7 +47,7 @@ RSpec.describe "the admin invoices show page" do
     visit admin_invoice_path(@invoice3.id)
 
     expect(page).to have_content("Invoice Number: #{@invoice3.id}")
-    expect(page).to have_content("Invoice Status: #{@invoice3.status}")
+    expect(page).to have_select("invoice_status" , selected: @invoice3.status.capitalize)
     expect(page).to have_content("Created On: #{@invoice3.created_at.strftime("%A, %B %d, %Y")}")
     expect(page).to have_content("Customer: #{@customer2.first_name} #{@customer2.last_name}")
   end
@@ -106,13 +106,13 @@ RSpec.describe "the admin invoices show page" do
 
     visit admin_invoice_path(invoice)
 
-    expect(page).to have_select("Status", selected: "Pending")
+    expect(page).to have_select("invoice_status", selected: "In progress")
 
-    select "Completed", from: "Status"
+    select "Completed", from: "invoice_status"
     click_button "Update Invoice Status"
 
     expect(current_path).to eq(admin_invoice_path(invoice))
-    expect(page).to have_select("Status", selected: "Completed")
-    expect(page).to have_select("Invoice has been Updated")
+    expect(page).to have_select("invoice_status", selected: "Completed")
+    expect(page).to have_text("Invoice has been Updated to completed")
   end
 end


### PR DESCRIPTION
As an admin
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated

*Added Specs, Flash message, select box for Invoice statuses